### PR TITLE
[Aazam]-[UserAccount Added-UnitTests-SignInForm]

### DIFF
--- a/app/components/SignIn/index.js
+++ b/app/components/SignIn/index.js
@@ -8,7 +8,11 @@ import TextField from 'components/_DesignWrappers/TextField';
 import CheckBoxField from 'components/_DesignWrappers/CheckBoxField';
 import TextLink from 'components/_DesignWrappers/TextLink';
 import Button from 'components/_DesignWrappers/Button';
-import { isBlankValidator, emailValidator, lengthCheckValidator } from 'components/Form/Validators';
+import {
+  isBlankValidator,
+  emailValidator,
+  lengthCheckValidator,
+} from 'components/Form/Validators';
 import config from 'config';
 
 import messages from './messages';
@@ -30,18 +34,18 @@ const SignIn = (props) => {
           </Avatar>
           <h2>{intl.formatMessage(messages.signIn)}</h2>
         </Grid2>
-        <LocalForm form="SignInForm" onSubmit={handleSignInSubmit}>
+        <LocalForm
+          form="SignInForm"
+          onSubmit={handleSignInSubmit}
+          data-test-id="signInForm"
+        >
           <TextField
             model=".email"
             label={intl.formatMessage(messages.emailLabel)}
             placeholder={intl.formatMessage(messages.emailPlaceholder)}
             validators={[
-              isBlankValidator(
-                intl.formatMessage(messages.emailError)
-              ),
-              emailValidator(
-                intl.formatMessage(messages.invalidEmailError)
-              ),
+              isBlankValidator(intl.formatMessage(messages.emailError)),
+              emailValidator(intl.formatMessage(messages.invalidEmailError)),
             ]}
             fullWidth
           />
@@ -51,12 +55,8 @@ const SignIn = (props) => {
             label={intl.formatMessage(messages.passwordLabel)}
             placeholder={intl.formatMessage(messages.passwordPlaceholder)}
             validators={[
-              isBlankValidator(
-                intl.formatMessage(messages.passwordError)
-              ),
-              lengthCheckValidator(
-                intl.formatMessage(messages.passwordLengthError), 8,
-              ),
+              isBlankValidator(intl.formatMessage(messages.passwordError)),
+              lengthCheckValidator(intl.formatMessage(messages.passwordLengthError), 8),
             ]}
             isPassword
             fullWidth
@@ -71,6 +71,7 @@ const SignIn = (props) => {
             color="primary"
             variant="contained"
             className={styles.signInButton}
+            data-test-id="signInSubmitButton"
             fullWidth
           >
             {intl.formatMessage(messages.signInButton)}

--- a/app/components/SignIn/tests/index.test.js
+++ b/app/components/SignIn/tests/index.test.js
@@ -1,12 +1,5 @@
 import React from 'react';
 import { Avatar } from '@mui/material';
-// import {
-//   Button,
-//   LocalForm,
-//   TextField,
-//   CheckBoxField,
-//   TextLink,
-// } from 'components/_DesignWrappers';
 import Button from 'components/_DesignWrappers/Button';
 import LocalForm from 'components/_DesignWrappers/LocalForm';
 import TextField from 'components/_DesignWrappers/TextField';

--- a/app/components/SignIn/tests/index.test.js
+++ b/app/components/SignIn/tests/index.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Avatar } from '@mui/material';
+// import {
+//   Button,
+//   LocalForm,
+//   TextField,
+//   CheckBoxField,
+//   TextLink,
+// } from 'components/_DesignWrappers';
+import Button from 'components/_DesignWrappers/Button';
+import LocalForm from 'components/_DesignWrappers/LocalForm';
+import TextField from 'components/_DesignWrappers/TextField';
+import CheckBoxField from 'components/_DesignWrappers/CheckBoxField';
+import TextLink from 'components/_DesignWrappers/TextLink';
+import { shallowWithIntl } from '@internals/testing/intl-enzyme-test-helper';
+import SignIn from '..';
+
+const signInUserMock = jest.fn();
+
+const defaultProps = {
+  signInUser: signInUserMock,
+};
+
+describe('SignIn component tests', () => {
+  const componentWrapper = shallowWithIntl(<SignIn {...defaultProps} />).dive();
+
+  it('should render SignIn component', () => {
+    expect(componentWrapper.find(LocalForm).length).toBe(1);
+    expect(componentWrapper.find(Avatar).length).toBe(1);
+    expect(componentWrapper.find(TextField).length).toBe(2);
+    expect(componentWrapper.find(CheckBoxField).length).toBe(1);
+    expect(componentWrapper.find(Button).length).toBe(1);
+    expect(componentWrapper.find(TextLink).length).toBe(2);
+  });
+  it('should render email and password textfields', () => {
+    expect(componentWrapper.find(TextField).length).toBe(2);
+    expect(componentWrapper.find(TextField).at(0).props().model).toEqual('.email');
+    expect(componentWrapper.find(TextField).at(1).props().model).toEqual('.password');
+  });
+  it('should dispatch signInUser action on form submit', () => {
+    const formDataMock = { email: 'test@gmail.com', password: 'test@1234' };
+    const signInForm = componentWrapper.find('[data-test-id="signInForm"]');
+
+    expect(signInForm.exists()).toBeTruthy();
+    signInForm.simulate('submit', { ...formDataMock });
+    expect(signInUserMock).toHaveBeenCalledWith(formDataMock);
+  });
+});


### PR DESCRIPTION
Ticket: PROJ-XXXX <br>
Linked PRs: (links to corresponding PRs, optional)

- [ ] Browser testing (Chrome, Firefox, Safari, Edge)<br>
- [ ] Accessibility testing (NVDA + Firefox, Voiceover + Safari)<br>
- [x] I have read and agreed to the process outlined in [Creating a Pull Request](File_Path for creatingPullRequest.md)<br> 
- [ ] I ran `npm run extract-intl` to update the messages generated
- [ ] If this is a *downstream* I have double checked that my *destination branch* is my *epic branch*

## Changes

* Added unit tests for signInForm.

## Code Coverage

- [x] Code coverage is greater than or equal to previous code coverage <br>

Previous code coverage: <br>
Current code coverage:

![image](https://github.com/user-attachments/assets/7f9f7cee-9cf1-4e2e-ab60-17772c3823c8)
